### PR TITLE
Add cflinuxfs5 support for Node.js buildpack

### DIFF
--- a/jobs/nodejs-buildpack/spec
+++ b/jobs/nodejs-buildpack/spec
@@ -3,6 +3,7 @@ name: nodejs-buildpack
 templates: {}
 
 packages:
+- nodejs-buildpack-cflinuxfs5
 - nodejs-buildpack-cflinuxfs4
 
 properties: {}

--- a/packages/nodejs-buildpack-cflinuxfs5/packaging
+++ b/packages/nodejs-buildpack-cflinuxfs5/packaging
@@ -1,0 +1,3 @@
+    set -e -x
+    cp nodejs-buildpack/nodejs?buildpack-*.zip ${BOSH_INSTALL_TARGET}
+

--- a/packages/nodejs-buildpack-cflinuxfs5/spec
+++ b/packages/nodejs-buildpack-cflinuxfs5/spec
@@ -1,0 +1,4 @@
+---
+name: nodejs-buildpack-cflinuxfs5
+files:
+- nodejs-buildpack/nodejs?buildpack-cflinuxfs5-*.zip


### PR DESCRIPTION
## Add cflinuxfs5 support for Node.js buildpack

This commit adds cflinuxfs5 (Ubuntu 24.04 noble) stack support to the nodejs-buildpack BOSH release, following the same pattern used for cflinuxfs4 addition in commit c5519f7.

### Changes:
- Create packages/nodejs-buildpack-cflinuxfs5/spec - package specification
- Create packages/nodejs-buildpack-cflinuxfs5/packaging - build script
- Update jobs/nodejs-buildpack/spec to reference cflinuxfs5 package

Both cflinuxfs4 and cflinuxfs5 packages will be included in future releases, enabling operators to deploy Node.js applications on either stack during the migration period from jammy (cflinuxfs4) to noble (cflinuxfs5).

The next BOSH release will include the cflinuxfs5 package, making it available for Cloud Foundry deployments.